### PR TITLE
Close applications, add Mailchimp signup for Bayes list

### DIFF
--- a/assets/stylesheet/style.css
+++ b/assets/stylesheet/style.css
@@ -102,6 +102,7 @@ a {
 }
 
 .button {
+  background: transparent;
   border: 2px solid white;
   color: white;
   padding: 12px 25px;
@@ -945,10 +946,6 @@ a {
     margin-top: 30px;
   }
 
-  #apply .apply-container {
-    margin: 0;
-  }
-
   #apply .apply-header {
     font-size: 22px
   }
@@ -1022,4 +1019,47 @@ a {
 
 .primary-alt {
   color: #02bfe7;
+}
+
+/* EMAIL SIGNUP */
+
+input {
+  font-size: 16px;
+  outline: none;
+}
+
+/* Email field*/
+.email {
+  width: 50%;
+  /* Padding like buttons */
+  padding: 12px;
+  border: 2px solid white;
+  border-radius: 2px;
+  background: transparent;
+  color: white;
+}
+input[type=email]:focus {
+    border: 2px solid #02bfe7;
+}
+
+input.button.apply {
+  font-size: inherit;
+}
+
+/* Placeholder text */
+::-webkit-input-placeholder {
+  font-style: italic;
+  color: #dce4ef;
+}
+:-moz-placeholder {
+  font-style: italic;
+  color: #dce4ef;
+}
+::-moz-placeholder {
+  font-style: italic;
+  color: #dce4ef;
+}
+:-ms-input-placeholder { 
+  font-style: italic; 
+   color: #dce4ef;  
 }

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                     <div class="sub-headline">Washington D.C. meets Silicon Valley.</div>
                     <div class="sub-headline mini">OpenDNS &middot; April 23-24</div>
                     <div class="button-container">
-                        <a class="button live" href="https://bayeshack.typeform.com/to/x4cRwx">Apply</a>
+                        <a class="button live" href="#apply">Apply</a>
                         <a class="button" href="mailto:hack@bayesimpact.org?subject=Bayes%20Hack%202016%20Sponsorship%20Inquiry">Sponsor</a>
                     </div>
                 </div>
@@ -149,8 +149,15 @@
         <div id="apply" class="section">
             <!-- <div class="desktop-img"></div> -->
             <div class="apply-container">
-                <div class="apply-header">Applications open now!<br/><span class="primary-alt">Let's hack social good.</span></div>
-                <a class="button apply" href="https://bayeshack.typeform.com/to/x4cRwx">I'm in!</a>
+                <div class="apply-header">You <em>just</em> missed us...
+                <br>2016 Applications are closed.
+                <br/><span class="primary-alt">Stay in the loop!</span></div>
+
+                <form action="http://bayesimpact.us8.list-manage.com/subscribe/post?u=91cb7b976eca90a97f3549c12&amp;id=b101094712" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate signup" target="_blank" novalidate>
+                    <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="e.g. your@email.com" required>
+                    <input type="submit" value="I'm in" name="subscribe" id="mc-embedded-subscribe" class="button apply">
+                </form>
+
             </div>
             <div class="slant bottom left"></div>
         </div>


### PR DESCRIPTION
@cconsidine this should actually get some testing.

I removed the application buttons (links to the typeform) and added a form field to sign up for the Bayes Impact mailing list in the `apply` section of the site.

They aren't critical, but if you have design suggestions for what to do with colors/selection in the input form I could definitely use them. Right now:

\1. White input field:

<img width="501" alt="screen shot 2016-04-12 at 2 44 23 pm" src="https://cloud.githubusercontent.com/assets/4955943/14476766/9069634c-00be-11e6-9ed8-02e214fae9e4.png">

\2. Border turns blue when text field selected:

<img width="471" alt="screen shot 2016-04-12 at 2 44 39 pm" src="https://cloud.githubusercontent.com/assets/4955943/14476774/9b1f9964-00be-11e6-9995-dbdf982493b6.png">

\3. Button turns red on hover, which is our standard conversion behavior:

<img width="378" alt="screen shot 2016-04-12 at 2 45 00 pm" src="https://cloud.githubusercontent.com/assets/4955943/14476784/a87bb818-00be-11e6-9eaa-97ed7cedd1a4.png">

Let me know what you think, and let's get this merged in today.
