### PR TITLE
Link to Bayes Impact starter kit repos in resource lists

### DIFF
--- a/commerce.html
+++ b/commerce.html
@@ -67,11 +67,13 @@
                     <h1 id="resources">Resources</h1>
                         <p>Consumer Financial Protection Bureau:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-commerce-complaints">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li><a href="http://www.consumerfinance.gov/complaintdatabase/">CFPB Consumer Complaint Database</a></li>
                             <li>The Commerce Data Service offers a tutorial for merging the American Community Survey's public datasets with the Consumer Complaint Database to highlight areas of specific need within particular communities: "<a href="http://commercedataservice.github.io/tutorial_acs_rank/">Extending the ACS: Data-driven Outreach</a>."</li>
                         </ul>
                         <p>VIIRS satelite data:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-commerce-satellite">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>"<a href="http://commercedataservice.github.io/tutorial_viirs_part1/">Data Science for Nighttime Lights</a>," an intro to processing the VIIRS dataset with R and Plotly from the <a href="https://github.com/commercedataservice">Commerce Data Service</a>.</li>
                             <li><a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4577086/">Evaluation of NPP-VIIRS Nighttime Light Data for Mapping Global Fossil Fuel Combustion CO<sub>2</sub> Emissions: A Comparison with DMSP-OLS Nighttime Light Data</a> by Jinpei Ou, Xia Li, Meifang Li, and Wenkai Li.</li>
                             <li><a href="http://martinprosperity.org/papers/Night-time%20LightData-Formatted.pdf">Night-Time Light Data: A good Proxy Measure for Economic Activity?</a> by Mellander et al. for Martin Prosperity Research, University of Toronto.</li>

--- a/health-and-human-services.html
+++ b/health-and-human-services.html
@@ -62,6 +62,7 @@
                     <h1 id="resources">Resources</h1>
                         <p>Insurance marketplaces:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-hhs-marketplace">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li><a href="https://www.cms.gov/CCIIO/Resources/Data-Resources/marketplace-puf.html">The CMS Health Insurance Marketplace Public Use Files</a>, this prompt's core dataset.</li>
                             <li><a href="https://www.kaggle.com/hhsgov/health-insurance-marketplace">HHS Health Insurance Marketplace challenge</a> on Kaggle.</li>
                             <li><a href="http://hhs.ddod.us/wiki/Interoperability:_Provider_network_directories">Directory data schemas</a> from the HHS DDOD.</li>
@@ -71,6 +72,7 @@
                         </ul>
                         <p>Opioid abuse:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-hhs-opioid-abuse">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>The Substance Abuse and Mental Health Services Administration (SAMHSA) compiles an <a href="http://store.samhsa.gov/shin/content//SMA16-4742/SMA16-4742.pdf">Opioid Overdose Prevention Toolkit</a> as a primer for caregivers and first-responders on the signs and treatments of various complications of opioid abuse.</li>
                             <li>The CDC <a href="http://www.cdc.gov/drugoverdose/data/overdose.html">aggregates data</a> on prescription opioid overdoses.</li>
                             <li>The Centers for Medicare &amp; Medicaid Services anonymize and collect <a href="https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/OpioidMap.html">geographic opioid prescription claim data</a> down to a ZIP code level.</li>

--- a/housing-and-urban-development.html
+++ b/housing-and-urban-development.html
@@ -56,6 +56,7 @@
 
                     <h1 id="resources">Resources</h1>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-hud-inequality">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>Brand new <a href="http://egis.hud.gov/affht/">HUD Affirmatively Furthering Fair Housing data</a> reatures six community asset indicators: Neighborhood School Proficiency, Poverty, Labor Market Engagement, Job Accessibility, Health Hazards Exposure, and Transit Access.</li>
                             <li><a href="http://opportunity.census.gov/">The Opportunity Project</a> combines additional federal and local open data to determine access to opportunity at neighborhood granularity.</li>
                             <li><a href="https://www.whitehouse.gov/omb/place/datasets">White House Community-Based Initiatives Data</a> features datasets from dozens of community empowerment projects.</li>

--- a/interior.html
+++ b/interior.html
@@ -56,6 +56,7 @@
 
                     <h1 id="resources">Resources</h1>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-interior">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li><a href="http://usda.github.io/RIDB/">The Recreation Information Database</a> (RIDB) is the API for federal recreation areas.</li>
                             <li><a href="https://irma.nps.gov/Portal">The Integrated Resource Management Applications Portal</a> (IRMA) is the home of National Park Service data, including planning processes and biodiversity.</li>
                             <li>The U.S. Fish &amp; Wildlife Service hosts <a href="http://www.fws.gov/gis/data/national/"> comprehensive geospatial data describing parks and ecosystems.</a></li>

--- a/labor.html
+++ b/labor.html
@@ -57,7 +57,6 @@
 
                     <h1 id="resources">Resources</h1>
                         <ul>
-                            <li>The <a href="https://github.com/bayesimpact/bayeshack-labor">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li><a href="http://www.onetcenter.org/database.html?p=2">The O*NET Resource Center</a> gives detailed information about work and worker characteristics, including the skillsets most pertinent to the current middle-skill shift.</li>
                             <li><a href="http://www.careeronestop.org/developers/data/data-downloads.aspx">CareerOneStop</a> hosts data on government workforce support programs primarily as a resource for workers; it's a useful dataset to evaluate the current state of support, to direct development of those support systems, and also to integrate into worker-facing applications.</li>
                             <li><a href="http://www.bls.gov/data/">The Bureau of Labor Statistics</a> collects and publishes a lot of labor statistics. Surprise! Specifically, <a href="http://www.bls.gov/cps/data.htm">Labor Force Statistics from the Current Population Survey</a> and <a href="http://www.bls.gov/oes/tables.htm">Occupational Employment Statistics data</a> might be of use.</li>

--- a/labor.html
+++ b/labor.html
@@ -56,8 +56,8 @@
                         <br><br>
 
                     <h1 id="resources">Resources</h1>
-                        <p>More and cleaner data to be added very, very soon.</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-labor">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li><a href="http://www.onetcenter.org/database.html?p=2">The O*NET Resource Center</a> gives detailed information about work and worker characteristics, including the skillsets most pertinent to the current middle-skill shift.</li>
                             <li><a href="http://www.careeronestop.org/developers/data/data-downloads.aspx">CareerOneStop</a> hosts data on government workforce support programs primarily as a resource for workers; it's a useful dataset to evaluate the current state of support, to direct development of those support systems, and also to integrate into worker-facing applications.</li>
                             <li><a href="http://www.bls.gov/data/">The Bureau of Labor Statistics</a> collects and publishes a lot of labor statistics. Surprise! Specifically, <a href="http://www.bls.gov/cps/data.htm">Labor Force Statistics from the Current Population Survey</a> and <a href="http://www.bls.gov/oes/tables.htm">Occupational Employment Statistics data</a> might be of use.</li>

--- a/transportation.html
+++ b/transportation.html
@@ -64,6 +64,7 @@
                     <h1 id="resources">Resources</h1>
                         <p>Transportation of hazardous materials:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-transportation-hazmat">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li><a href="http://www.eia.gov/opendata/index.cfm">Energy Information Administration (EIA) open data</a></li>
                             <li><a href="http://energy.gov/fe/downloads/electronic-docket-room-e-docket-room">Department of Energy data</a> on the registration of import/export permits for LNG at the Office of Fossil Energy</li>
                             <li><a href="http://www.ferc.gov/industries/gas/indus-act/lng.asp">Federal Energy Regulatory Commission (FERC) data</a> on LNG terminals and other facilities</li>
@@ -74,11 +75,13 @@
                         </ul>
                         <p>Suicide prevention:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-transportation-railroad">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li><a href="https://drive.google.com/file/d/0B-velHZJGPpOVF9ueHJsNWI0ZUk/view">Rail casualty CSV data</a></li>
                             <li><a href="https://hifld-dhs-gii.opendata.arcgis.com/datasets?group_id=46386d78e5a446a89b3beae51979b001">HIFLD geospatial data</a> on various transportatoin infrastructure features, including railroads, railroad tunnels, railroad bridges, and rail junctions.</li>
                         </ul>
                         <p>Emergency services:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-transportation-ems">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>2014 National EMS Dataset: coordinating download logistics. Will be available before event.</li>
                             <li>State of Illinois EMS Dataset: ditto.</li>
                             <li>The American Trauma Society hosts a <a href="http://www.amtrauma.org/?page=FindTraumaCenter">comprehensive index of trauma centers</a> in the United States that incorporates service information.</li>

--- a/veterans-affairs.html
+++ b/veterans-affairs.html
@@ -62,10 +62,12 @@
                     <h1 id="resources">Resources</h1>
                         <p>Suicide prevention:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-va-suicide">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>Datasets coming soon; we're working actively with our partners at the Department of Veterans Affairs to get high-quality non-aggregate data for this prompt.</li>
                         </ul>
                         <p>End Stage Renal Disease:</p>
                         <ul>
+                            <li>The <a href="https://github.com/bayesimpact/bayeshack-va-kidney">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>The <a href="http://www.usrds.org/2015/view/Default.aspx">United States Renal Data System</a> offers aggregate data on the identification, care, and costs of ESRD and Chronic Kidney Disease.</li>
                             <li>Medicare <a href="https://data.medicare.gov/data/dialysis-facility-compare">Dialysis Facility Compare datasets</a> enable quality of care analysis of all Medicare-certified dialysis facilities in the United States. The same site also hosts a number of <a href="https://data.medicare.gov/data?tool=dialysis-facility-compare&amp;tag=&amp;sort=relevance&amp;q">other ESRD datasets</a> Medicare uses to assess care center quality.</li>
                             <li>The Centers for Medicare &amp; Medicaid Services still offer 'vintage' <a href="https://www.cms.gov/Medicare/End-Stage-Renal-Disease/ESRDGeneralInformation/Data.html">ESRD program data</a> for 2003-2004.</li>

--- a/veterans-affairs.html
+++ b/veterans-affairs.html
@@ -62,12 +62,10 @@
                     <h1 id="resources">Resources</h1>
                         <p>Suicide prevention:</p>
                         <ul>
-                            <li>The <a href="https://github.com/bayesimpact/bayeshack-va-suicide">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>Datasets coming soon; we're working actively with our partners at the Department of Veterans Affairs to get high-quality non-aggregate data for this prompt.</li>
                         </ul>
                         <p>End Stage Renal Disease:</p>
                         <ul>
-                            <li>The <a href="https://github.com/bayesimpact/bayeshack-va-kidney">Bayes Impact starter kit</a>, an exploration of this prompt's key datasets.</li>
                             <li>The <a href="http://www.usrds.org/2015/view/Default.aspx">United States Renal Data System</a> offers aggregate data on the identification, care, and costs of ESRD and Chronic Kidney Disease.</li>
                             <li>Medicare <a href="https://data.medicare.gov/data/dialysis-facility-compare">Dialysis Facility Compare datasets</a> enable quality of care analysis of all Medicare-certified dialysis facilities in the United States. The same site also hosts a number of <a href="https://data.medicare.gov/data?tool=dialysis-facility-compare&amp;tag=&amp;sort=relevance&amp;q">other ESRD datasets</a> Medicare uses to assess care center quality.</li>
                             <li>The Centers for Medicare &amp; Medicaid Services still offer 'vintage' <a href="https://www.cms.gov/Medicare/End-Stage-Renal-Disease/ESRDGeneralInformation/Data.html">ESRD program data</a> for 2003-2004.</li>


### PR DESCRIPTION
This is the first step in a migration to just using the Bayes Impact GitHub repo as the go-to place for prompts resources.

After a verification process and adding additional resource links currently listed on the prompts pages to the repos, we will link straight to the repos from bayeshack.org (instead of to website prompts pages). This will be good.

This is just so we can get the logistics emails out.

Edit: not linking to the empty repos for the time being. Once we add resource lists to those repos, we'll link from the site––both the main page and the prompt page. Later PR.
